### PR TITLE
Add a possibility to use globalVars / modifyVars as a second option

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,6 @@ module.exports = function (options, additionalData) {
 
       // all is ok
       file.contents = new Buffer(css);
-      file.path = gutil.replaceExtension(file.path, '.css');
 
       if (file.sourceMap) {
         var comment = convert.fromSource(css);
@@ -78,6 +77,7 @@ module.exports = function (options, additionalData) {
         }
       }
 
+      file.path = gutil.replaceExtension(file.path, '.css');
       cb(null, file);
     }, additionalData);
   });

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ module.exports = function (options, additionalData) {
     }
 
     var parser = new (less.Parser)(opts);
-    parser.parse(str, opts, function (err, css) {
+    var errCb = function (err, css) {
       if (err) {
 
         // Convert the keys so PluginError can read them
@@ -51,24 +51,34 @@ module.exports = function (options, additionalData) {
         err.message = err.message + ' in file ' + err.fileName + ' line no. ' + err.lineNumber;
 
         return cb(new PluginError('gulp-less', err));
-      } else {
-        file.contents = new Buffer(css);
-        file.path = gutil.replaceExtension(file.path, '.css');
-
-        if (file.sourceMap) {
-          var comment = convert.fromSource(css);
-          if (comment) {
-            file.contents = new Buffer(convert.removeComments(css));
-            var sourceMap = comment.sourcemap;
-            for (var i = 0; i < sourceMap.sources.length; i++) {
-              sourceMap.sources[i] = path.relative(file.base, sourceMap.sources[i]);
-            }
-            applySourceMap(file, sourceMap);
-          }
-        }
-
-        cb(null, file);
       }
+    };
+
+    parser.parse(str, function (e, root) {
+      if (e) { errCb(e); return; }
+      var css;
+      try {
+        css = root && root.toCSS && root.toCSS(options);
+      }
+      catch (err) { errCb(err); return; }
+
+      // all is ok
+      file.contents = new Buffer(css);
+      file.path = gutil.replaceExtension(file.path, '.css');
+
+      if (file.sourceMap) {
+        var comment = convert.fromSource(css);
+        if (comment) {
+          file.contents = new Buffer(convert.removeComments(css));
+          var sourceMap = comment.sourcemap;
+          for (var i = 0; i < sourceMap.sources.length; i++) {
+            sourceMap.sources[i] = path.relative(file.base, sourceMap.sources[i]);
+          }
+          applySourceMap(file, sourceMap);
+        }
+      }
+
+      cb(null, file);
     }, additionalData);
   });
 };

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var defaults = require('lodash.defaults');
 var convert = require('convert-source-map');
 var applySourceMap = require('vinyl-sourcemaps-apply');
 
-module.exports = function (options) {
+module.exports = function (options, additionalData) {
   // Mixes in default options.
   options = defaults(options || {}, {
     compress: false,
@@ -39,7 +39,8 @@ module.exports = function (options) {
       opts.sourceMap = true;
     }
 
-    less.render(str, opts, function (err, css) {
+    var parser = new (less.Parser)(opts);
+    parser.parse(str, opts, function (err, css) {
       if (err) {
 
         // Convert the keys so PluginError can read them
@@ -68,7 +69,7 @@ module.exports = function (options) {
 
         cb(null, file);
       }
-    });
+    }, additionalData);
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-less",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Less for Gulp",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "gitHead": "507383fe7771a092e8a7bcb23a9bd33c1904ce34",
   "dependencies": {
     "convert-source-map": "^0.4.0",
-    "gulp-util": "^3.0.0",
+    "gulp-util": "^2.2.5",
     "less": "^1.7.4",
     "lodash.defaults": "^2.4.1",
     "through2": "^0.5.1",


### PR DESCRIPTION
Fix issue #67, i.e:
...
  gulp.src('*.less')
    .pipe(less(undefined, {
      modifyVars: {
        'backgroundColor': '#fff',
        'customerId': 'Apple'
      }
    })
...