### PR TITLE
Pass sourcesContent to sourceMap && add test

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,8 +59,10 @@ module.exports = function (options) {
           if (comment) {
             file.contents = new Buffer(convert.removeComments(css));
             var sourceMap = comment.sourcemap;
+            sourceMap.sourcesContent = [];
             for (var i = 0; i < sourceMap.sources.length; i++) {
               sourceMap.sources[i] = path.relative(file.base, sourceMap.sources[i]);
+              sourceMap.sourcesContent.push(file.contents.toString());
             }
             sourceMap.file = file.relative;
             applySourceMap(file, sourceMap);

--- a/test/main.js
+++ b/test/main.js
@@ -150,5 +150,36 @@ describe('gulp-less', function () {
       });
       stream.end();
     });
+
+    it('should provide sourcesContent to sourceMap', function (done) {
+      var files = [
+        createVinyl('buttons.less'),
+        createVinyl('forms.less'),
+        createVinyl('normalize.less')
+      ] .map(function (file) {
+        file.sourceMap = {
+          file: '',
+          version : 3,
+          sourceRoot : '',
+          sources: [],
+          names: [],
+          mappings: '',
+          sourcesContent: []
+        };
+        return file;
+      });
+
+      var stream = less();
+      var count = files.length;
+      stream.on('data', function (cssFile) {
+        should.exist(cssFile.sourceMap.sourcesContent);
+      });
+      stream.on('end', done);
+
+      files.forEach(function (file) {
+        stream.write(file);
+      });
+      stream.end();
+    });
   });
 });


### PR DESCRIPTION
Ran into an issue with [`gulp-autoprefixer`](https://github.com/sindresorhus/gulp-autoprefixer/pull/3) that led to discovering that `gulp-less` doesn't properly pass `sourcesContent` to `sourceMap`. For example, if you have a `.less` file with an `@import`, you end up with both the imported file and importing file in `sources`, but a `null` in `sourcesContent` for the imported file. 

Per @floridoo, `sourcesContent` a required property. Seems to cause warnings/errors downstream when not passed properly.

This PR:

1. Adds a `sourcesContent` property to `sourceMap`
2. Recursively pushes `file.contents.toString()` from `sourceMap.sources` into `sourcesContent`
3. Adds a test for this functionality