### PR TITLE
Correct use of promises.

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,8 +56,7 @@ module.exports = function (options) {
           }
 
           cb(null, file);
-    }, function(err){
-        console.log(err);
+    }).catch(function(err){
         // Convert the keys so PluginError can read them
         err.lineNumber = err.line;
         err.fileName = err.filename;
@@ -65,7 +64,7 @@ module.exports = function (options) {
         // Add a better error message
         err.message = err.message + ' in file ' + err.fileName + ' line no. ' + err.lineNumber;
 
-        cb(new PluginError('gulp-less', err), null);
-      });
+        throw new PluginError('gulp-less', err);
+    }).done(undefined, cb);
   });
 };


### PR DESCRIPTION
fixes #118

As mentioned in #131, current tip (before this merge) causes following error:
```
Error in plugin 'gulp-less'
Message:
    'font-awesome/less/variables.less' wasn't found. Tried - /home/ch/src/Browser/style/font-awesome/less/variables.less,font-awesome/less/variables.less in file /home/ch/src/Browser/style/config.less line no. 1
Details:
    type: File
    filename: /home/ch/src/Browser/style/config.less
    index: 0
    line: 1
    callLine: NaN
    callExtract: undefined
    column: 0
    extract: ,@import "font-awesome/less/variables";,
    lineNumber: 1
    fileName: /home/ch/src/Browser/style/config.less
```
Please, be wary.