### PR TITLE
Fix a test bug about timeout

### DIFF
--- a/test/main.js
+++ b/test/main.js
@@ -72,6 +72,8 @@ describe('gulp-less', function () {
       stream.once('error', function (err) {
         err.message.should.equal('variable @undefined-variable is undefined in file '+errorFile.path+' line no. 1');
         errorCalled = true;
+        errorCalled.should.equal(true);
+        done();
       });
       stream.once('end', function(){
         errorCalled.should.equal(true);


### PR DESCRIPTION
> When an error event is fired, the end event will not be fired(explicitly). The emitting of an error event will end the stream. - http://stackoverflow.com/questions/21771220/error-handling-with-node-js-streams