### PR TITLE
Restore the original Options

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,10 +9,10 @@ var applySourceMap = require('vinyl-sourcemaps-apply');
 
 module.exports = function (options) {
   // Mixes in default options.
-  options = assign({}, options, {
-    compress: false,
-    paths: []
-  });
+  options = assign({}, {
+      compress: false,
+      paths: []
+    }, options);
 
   return through2.obj(function(file, enc, cb) {
     if (file.isNull()) {


### PR DESCRIPTION
Rewriting the Options doesn't make sense and gulp started breaking after last update.
Default options should be overridden by custom ones, not the custom one by Defaults.