### PR TITLE
Fix relative path for sourcemap.sources

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,8 +40,8 @@ module.exports = function (options) {
       file.path = gutil.replaceExtension(file.path, '.css');
       if (res.sourcemap) {
         res.sourcemap.file = file.path;
-        res.sourcemap.sources = res.sourcemap.sources.map(function(filePath) {
-			return path.relative(file.base, filePath);
+        res.sourcemap.sources = res.sourcemap.sources.map(function() {
+			return file.relative;
         });		
         applySourceMap(file, res.sourcemap);
       }

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports = function (options) {
         file.path = gutil.replaceExtension(file.path, '.css');
         if (res.sourcemap) {
             res.sourcemap.file = file.path;
-            res.sourcemap.sources = res.sourcemap.sources.map(function(filePath) {
+            res.sourcemap.sources = res.sourcemap.sources.map(function() {
                 return file.relPath;
             });
             applySourceMap(file, res.sourcemap);

--- a/index.js
+++ b/index.js
@@ -40,6 +40,9 @@ module.exports = function (options) {
       file.path = gutil.replaceExtension(file.path, '.css');
       if (res.sourcemap) {
         res.sourcemap.file = file.path;
+        res.sourcemap.sources = res.sourcemap.sources.map(function(filePath) {
+			return path.relative(file.base, filePath);
+        });		
         applySourceMap(file, res.sourcemap);
       }
       return file;

--- a/index.js
+++ b/index.js
@@ -37,7 +37,6 @@ module.exports = function (options) {
 
     less.render(str, opts).then(function(res) {
       file.contents = new Buffer(res.result);
-      file.path = gutil.replaceExtension(file.path, '.css');
       if (res.sourcemap) {
         res.sourcemap.file = file.path;
         res.sourcemap.sources = res.sourcemap.sources.map(function() {
@@ -45,6 +44,7 @@ module.exports = function (options) {
         });		
         applySourceMap(file, res.sourcemap);
       }
+	  file.path = gutil.replaceExtension(file.path, '.css');
       return file;
     }).then(function(file) {
       cb(null, file); 

--- a/index.js
+++ b/index.js
@@ -29,24 +29,24 @@ module.exports = function (options) {
     // Clones the options object
     var opts = assign({}, options);
 
-      // Injects the path of the current file & fix paths if Windows style paths
-      opts.filename = file.path.split(path.sep).join('/');
+    // Injects the path of the current file & fix paths if Windows style paths
+    opts.filename = file.path.split(path.sep).join('/');
 
     // Bootstrap source maps
     if (file.sourceMap) { opts.sourcemap = true; }
 
     less.render(str, opts).then(function(res) {
-        file.contents = new Buffer(res.result);
-        file.relPath = file.relative;
-        file.path = gutil.replaceExtension(file.path, '.css');
-        if (res.sourcemap) {
-            res.sourcemap.file = file.path;
-            res.sourcemap.sources = res.sourcemap.sources.map(function() {
-                return file.relPath;
-            });
-            applySourceMap(file, res.sourcemap);
-        }
-        return file;
+      file.contents = new Buffer(res.result);
+      file.relPath = file.relative;
+      file.path = gutil.replaceExtension(file.path, '.css');
+      if (res.sourcemap) {
+        res.sourcemap.file = file.path;
+        res.sourcemap.sources = res.sourcemap.sources.map(function() {
+          return file.relPath;
+        });
+        applySourceMap(file, res.sourcemap);
+      }
+      return file;
     }).then(function(file) {
       cb(null, file); 
     }).catch(function(err) {


### PR DESCRIPTION
I'm trying to use <code>gulp-less</code> with <code>gulp-sourcemaps</code> and in "*.css.map" files I have a full path to sources.

My gulp task example:

<pre>
gulp.task('less', function () {
    gulp.src('public/assets/less/**/*.less')
        .pipe(sourcemaps.init())
        .pipe(less({
            strictMath: true,
            strictUnits: true
        }))
        .pipe(sourcemaps.write('map', {
            includeContent: false,
            sourceRoot: '/assets/less/'
        }))
        .pipe(gulp.dest('public/assets/css'));
});
</pre>

My sourcemap example:
<pre>
{
  "version": 3,
  "sources": ["f:/domains/gulp/public/assets/less/test.less"],
  "names": [],
  "mappings": "AAAA;EACI,sBAAA",
  "file": "test.css",
  "sourceRoot": "/assets/less/"
}
</pre>

Usage <code>base</code> option on <code>gulp.src</code> or <code>paths</code> option on <code>pipe(less())</code> doesn't solve the problem. While using <code>gulp-sourcemaps</code> with other plugins, like <code>gulp-typescript</code> - everything is fine.