### PR TITLE
Make sourcemap file and sources relative

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,11 @@ module.exports = function (options) {
       file.contents = new Buffer(res.result);
       file.path = gutil.replaceExtension(file.path, '.css');
       if (res.sourcemap) {
-        res.sourcemap.file = file.path;
+        res.sourcemap.file = file.relative;
+        res.sourcemap.sources = res.sourcemap.sources.map(function (source) {
+          return path.relative(file.base, source);
+        });
+
         applySourceMap(file, res.sourcemap);
       }
       return file;


### PR DESCRIPTION
This makes the sourcemap file and sources attributes relative to the file's base.

This will make gulp-less play nicely with gulp-postcss, as that is how it handles sourcemaps. This is similar to #154 (assuming its issues are resolved), but the addition of setting `res.sourcemap.file = file.relative` is necessary to let gulp-postcss know it can combine its sourcemap with gulp-less's.