### PR TITLE
relative paths in sourcemaps redoux

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,8 +34,10 @@ module.exports = function (options) {
 
     // Bootstrap source maps
     if (file.sourceMap) {
+      var basepath = path.resolve(file.base);
       opts.sourceMap = {
-        sourceMapBasepath: path.resolve(file.base)
+        sourceMapBasepath: basepath,
+        sourceMapRootpath: basepath
       };
     }
 

--- a/index.js
+++ b/index.js
@@ -33,17 +33,17 @@ module.exports = function (options) {
     opts.filename = file.path;
 
     // Bootstrap source maps
-    if (file.sourceMap) { opts.sourcemap = true; }
+    if (file.sourceMap) {
+      opts.sourceMap = {
+        sourceMapBasepath: path.resolve(file.base)
+      };
+    }
 
     less.render(str, opts).then(function(res) {
       file.contents = new Buffer(res.result);
       file.path = gutil.replaceExtension(file.path, '.css');
       if (res.sourcemap) {
-        res.sourcemap.file = file.relative;
-        res.sourcemap.sources = res.sourcemap.sources.map(function (source) {
-          return path.relative(file.base, source);
-        });
-
+        res.sourcemap.file = file.path;
         applySourceMap(file, res.sourcemap);
       }
       return file;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-less",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Less for Gulp",
   "main": "index.js",
   "scripts": {
@@ -19,7 +19,6 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
-    "accord": "^0.15.2",
     "gulp-util": "^3.0.4",
     "less": "^2.4.0",
     "object-assign": "^2.0.0",


### PR DESCRIPTION
Even if this problem was already fixed here plus3network/gulp-less/pull/161, I think my fix is a bit better, as instead of forcing all generated sources to be relative, I fixed configuration for less, so that it generates proper paths in the first place. That way a bit more processing is delegated to less, making this plugin more transparent. 