### PR TITLE
Added the ability to keep it from throwing errors when there is an issue in the less file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ The options you can use [can be found here](http://lesscss.org/#using-less-confi
 
 The `filename` option is not necessary, it's handled automatically by this plugin. The `compress` option is not supported -- if you are trying to minify your css, use [gulp-minify-css](https://github.com/jonathanepollack/gulp-minify-css). No `sourceMap` options are supported -- if you are trying to generate sourcemaps, use [gulp-sourcemaps](https://github.com/floridoo/gulp-sourcemaps).
 
+Additionally there is the `failOnError` boolean option that will print the error to the console instead of throwing it when it is set to false.  This is useful when using `gulp.watch` so it does not force you to restart gulp after encountering an error.
+
 ## Minifying CSS
 
 If you want to minify/compress your css, you can use either the [gulp-minify-css](https://github.com/jonathanepollack/gulp-minify-css) plugin for gulp, or the [less-clean-css](https://github.com/less/less-plugin-clean-css) plugin for less. Examples of both are shown below:

--- a/index.js
+++ b/index.js
@@ -65,6 +65,7 @@ module.exports = function (options) {
         throw pluginError;
       } else {
         gutil.log(pluginError.toString());
+        file.less = { error: pluginError };
         cb(null, file);
       }
     }).done(undefined, cb);

--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ module.exports = function (options) {
   // Mixes in default options.
   options = assign({}, {
       compress: false,
-      paths: []
+      paths: [],
+      failOnError: true
     }, options);
 
   return through2.obj(function(file, enc, cb) {
@@ -57,7 +58,15 @@ module.exports = function (options) {
       // Add a better error message
       err.message = err.message + ' in file ' + err.fileName + ' line no. ' + err.lineNumber;
 
-      throw new PluginError('gulp-less', err);
+      // Make sure that we are only failing on an error if we want to, otherwise
+      // we print the information out
+      var pluginError = new PluginError('gulp-less', err, {showProperties: false});
+      if (opts.failOnError) {
+        throw pluginError;
+      } else {
+        gutil.log(pluginError.toString());
+        cb(null, file);
+      }
     }).done(undefined, cb);
   });
 };

--- a/test/main.js
+++ b/test/main.js
@@ -83,6 +83,26 @@ describe('gulp-less', function () {
       stream.end();
     });
 
+    it('should return file with error when less contains errors', function (done) {
+      var errorCalled = false;
+      var stream = less({failOnError: false});
+      var errorFile = createVinyl('somefile.less',
+        new Buffer('html { color: @undefined-variable; }'));
+      stream.once('data', function (cssFile) {
+        should.exist(cssFile.less);
+        should.exist(cssFile.less.error)
+        cssFile.less.error.message.should.equal('variable @undefined-variable is undefined in file '+errorFile.path+' line no. 1');
+        errorCalled = true;
+        errorCalled.should.equal(true);
+        done();
+      });
+      stream.once('end', function(){
+        errorCalled.should.equal(true);
+      });
+      stream.write(errorFile);
+      stream.end();
+    });
+
     it('should compile multiple less files', function (done) {
       var files = [
         createVinyl('buttons.less'),


### PR DESCRIPTION
The main reason for this change is to keep it from ending your gulp.watch, and instead it will just print out the error to the terminal and then continue on.

Here is a small example of what you would do to use this functionality.
```javascript
gulp.task('default', function() {
  return gulp.src("main.less")
    .pipe(gulpLess({
      failOnError: false
    })). pipe(gulp.dest("."));
});
```