### PR TITLE
Update accord dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "Chris Cowan",
   "license": "MIT",
   "dependencies": {
-    "accord": "^0.20.1",
+    "accord": "^0.22.3",
     "gulp-util": "^3.0.7",
     "less": "^2.6.0",
     "object-assign": "^4.0.1",


### PR DESCRIPTION
The listed accord dep depends on a version of uglify-js with [known vulns](https://nodesecurity.io/advisories/48). I updated the dep and ran the tests.