### PR TITLE
upgrade accord dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "Chris Cowan",
   "license": "MIT",
   "dependencies": {
-    "accord": "^0.22.4",
+    "accord": "^0.22.5",
     "gulp-util": "^3.0.7",
     "less": "^2.6.0",
     "object-assign": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "Chris Cowan",
   "license": "MIT",
   "dependencies": {
-    "accord": "^0.20.1",
+    "accord": "^0.22.4",
     "gulp-util": "^3.0.7",
     "less": "^2.6.0",
     "object-assign": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "Chris Cowan",
   "license": "MIT",
   "dependencies": {
-    "accord": "^0.22.5",
+    "accord": "^0.23.0",
     "gulp-util": "^3.0.7",
     "less": "^2.6.0",
     "object-assign": "^4.0.1",


### PR DESCRIPTION
accord depends on fobject. 
fobject depended on an old version of graceful-fs that wasn't compatible with node 6, but this has been fixed now in both fobject and accord.

this is untested and submitted through the GH website, but should work fine?