### PR TITLE
Less peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Less for Gulp",
   "main": "index.js",
   "scripts": {
-    "test": "jshint index.js && node_modules/.bin/mocha"
+    "test": "jshint index.js && mocha"
   },
   "repository": {
     "type": "git",
@@ -20,16 +20,19 @@
   ],
   "author": "Chris Cowan",
   "license": "MIT",
+  "peerDependencies": {
+    "less": ">=2.x"
+  },
   "dependencies": {
     "accord": "^0.23.0",
     "gulp-util": "^3.0.7",
-    "less": "^2.6.0",
     "object-assign": "^4.0.1",
     "through2": "^2.0.0",
     "vinyl-sourcemaps-apply": "^0.2.0"
   },
   "devDependencies": {
     "jshint": "^2.4.1",
+    "less": "^2.6.0",
     "mocha": "^2.4.5",
     "should": "^7.1.1"
   }


### PR DESCRIPTION
There is a current issue open in less/less.js#2896 for the latest release `2.7.0`

When using `gulp-less` npm installs `less@2.7.0` as a dependency.

This PR proposes changing less to be a peer-dependency.

I'm not sure if the range I've specified is the right approach ie `"less": ">=2.x"`. This may need changing to `"less": "<3"` or something everyone can agree on..

There may be other finer points to this that I'm missing, though I did see this suggested in #183

Also note, this may need a major version bump as people will need to have less as an explicit dependency.