### PR TITLE
Make sure we explicitly skip the 2.7.0 release of less

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "accord": "^0.23.0",
     "gulp-util": "^3.0.7",
-    "less": "^2.6.0",
+    "less": "2.6.x || ^2.7.1",
     "object-assign": "^4.0.1",
     "through2": "^2.0.0",
     "vinyl-sourcemaps-apply": "^0.2.0"


### PR DESCRIPTION
Would fix #237 by **skipping the 2.7.0 release** altogether and allow users that have 2.6.x installed to keep it when they update gulp-less